### PR TITLE
Fixes inconsistent wasAssociatedWith issue 

### DIFF
--- a/provtemplates/provconv.py
+++ b/provtemplates/provconv.py
@@ -1106,7 +1106,6 @@ def match(eid,mdict, node, numEntries=1):
 	Returns:
 		meid: same as input or matching value for eid key in mdict
 	'''
-	print("match(eid=%s, mdict=%s, node=%s, numEntries=%d" % (eid, mdict, node, numEntries))
 	adr=eid
 	if isinstance(adr,prov.QualifiedName):
 		lp = adr.localpart

--- a/provtemplates/provconv.py
+++ b/provtemplates/provconv.py
@@ -951,14 +951,14 @@ def add_records(old_entity, new_entity, instance_dict):
 		
 		#we also want grouped relation attribute names
 		linkedRelAttrs=[]
-		for group in linkedGroups:
+		for fa1 in rel.formal_attributes:
 			lst=[]
-			for fa1 in rel.formal_attributes:
+			for group in linkedGroups:
 				if fa1[1] in group:
 					lst.append(fa1[0])
 			if len(lst)>0:
 				linkedRelAttrs.append(lst)
-		
+
 
 		#print repr(linkedRelAttrs)
 
@@ -1005,6 +1005,7 @@ def match(eid,mdict, node, numEntries=1):
 	Returns:
 		meid: same as input or matching value for eid key in mdict
 	'''
+	print("match(eid=%s, mdict=%s, node=%s, numEntries=%d" % (eid, mdict, node, numEntries))
 	adr=eid
 	if isinstance(adr,prov.QualifiedName):
 		lp = adr.localpart
@@ -1015,8 +1016,9 @@ def match(eid,mdict, node, numEntries=1):
 	#not optimal, need ability to provide custom namespace
 
 	# FIX NAMESPACE FOR UUID!!!!!!!!
-
-	if node and "vargen:" in str(adr) and str(adr)[:7]=="vargen:":
+	if adr in mdict:
+		madr = mdict[adr]
+	elif node and "vargen:" in str(adr) and str(adr)[:7]=="vargen:":
 		ret=None
 		for e in range(0,numEntries):
 			uid=str(uuid.uuid4())
@@ -1029,15 +1031,12 @@ def match(eid,mdict, node, numEntries=1):
 					tmp.append(mdict[adr])
 					mdict[adr]=tmp
 					tmp2=list()
-					tmp2.append(ret)
+					if ret: tmp2.append(ret)
 					ret=tmp2
 				qn=prov.QualifiedName(GLOBAL_UUID_DEF_NS, uid)
 				mdict[adr].append(qn)
 				ret.append(qn)
 		return ret
-	if adr in mdict:
-		#print("Match: ",adr)
-		madr = mdict[adr]
 	else:
 		#print("No Match: ",adr)
 		madr = eid 


### PR DESCRIPTION
Hi Doron,

this issue #4 was starting to be a show stopper for us, so we decided to spend some 
time trying to solve it. Please review and merge if possible. Thank you. Below is
a description of what I did.

`rel.formal_attributes` now determines the order in which matches are found.
It seems as if `linkedGroups` order is not always the same, whereas the
order of `rel.formal_attributes` order is always the same. So reversing
the loops makes that the order in which matches are found is now determined
by the order of `rel.formal_attributes` as opposed to `linkedGroups`.

Also in `match` there was an issue in which it was possible that `ret` was
not changed from its `None` initialization, causing `append` to be called on
a `None` object resulting in an exception. Also turned the order of the tests
around, because sometimes an empty list (or `None` before the `ret` fix was
returned when `adr` was in `mdict` and would have returned a value if this
test was first, which it now is.